### PR TITLE
Don't fake value for nullable property by default

### DIFF
--- a/src/Fakeable.php
+++ b/src/Fakeable.php
@@ -34,8 +34,10 @@ trait Fakeable
             if ($type instanceof ReflectionUnionType) {
                 throw new RuntimeException('Cannot fake union type');
             } else if ($type instanceof ReflectionNamedType) {
-                $class = $type->getName();
-                $value = FakerRegistrar::faker($class)(class: $class, value: $value);
+                if (!$type->allowsNull()) {
+                    $class = $type->getName();
+                    $value = FakerRegistrar::faker($class)(class: $class, value: $value);
+                }
             } else {
                 $value ??= false;
             }

--- a/tests/FakeableTest.php
+++ b/tests/FakeableTest.php
@@ -63,9 +63,11 @@ class FakeableTest extends TestCase
 
     public function test_nullable_works(): void
     {
-        $dto = Nullable::fake();
+        $dto1 = Nullable::fake();
+        $dto2 = Nullable::fake(name: 'hello');
 
-        $this->assertTrue(is_string($dto->name));
+        $this->assertTrue(is_null($dto1->name));
+        $this->assertTrue(is_string($dto2->name));
     }
 
     public function test_nested_dto_works(): void


### PR DESCRIPTION
When you have a DTO like:

```php
class Profile extends FakeableDataTransferObject
{
    public ?string $name;
}

$profile = Profile::fake();
```

currently, `$profile->name` will always be `string`, and if you really want it to be `null`, you have to do this manually:

```
$profile->name = null
```

now, `name` will always be `null` by default, unless you pass some value to it.

```php
$p1 = Profile::fake();
$p2 = Profile::fake(name: 'name');

var_dump(is_null($p1->name)); // true
var_dump(is_string($p2->name)); // true
```