### PR TITLE
Support CarbonImmutable

### DIFF
--- a/src/FakeableServiceProvider.php
+++ b/src/FakeableServiceProvider.php
@@ -42,14 +42,10 @@ class FakeableServiceProvider extends ServiceProvider
     protected function registerCarbonFaker(): void
     {
         FakerRegistrar::register(CarbonInterface::class, function (string $class, $value = null) {
-            if (blank($value)) {
-                return now();
-            }
-
             /**
              * @var CarbonInterface $class
              */
-            return $class::parse($value);
+            return blank($value) ? $class::now() : $class::parse($value);
         });
     }
 


### PR DESCRIPTION
This fixes an issue where if you have a DTO that requires a `CarbonImutable` instance would throw an exception

```php
class TestData extends DataTransferObject
{
    public CarbonImmutable $birthday;
}

TestData::fake() // error because now() will return a Carbon instance not CarbonImmutable
```

In this case, the current version would crash because `now()` may return an instance of `Carbon` not `CarbonImmutable`